### PR TITLE
Update typescript signature for stringify method

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,4 @@
 declare function stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
+declare function stringify(value: any, replacer?: (number | string)[] | null, space?: string | number): string;
 
 export default stringify;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,3 @@
-declare function stringify(data: any): string;
+declare function stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
 
 export default stringify;


### PR DESCRIPTION
The signature for `stringify` only had the first parameter.  The `replacer` and `space` parameters were not included.  This PR updates the signature to match the sig of `JSON.stringify`.