### PR TITLE
fixed simple stringify where object has undefined properties

### DIFF
--- a/stable.js
+++ b/stable.js
@@ -559,18 +559,15 @@ function stringifySimple (key, value, stack) {
         return '{}'
       }
       stack.push(value)
+      let separator = ''
       res = '{'
-      for (i = 0; i < keys.length - 1; i++) {
+      for (i = 0; i < keys.length; i++) {
         key = keys[i]
         const tmp = stringifySimple(key, value[key], stack)
         if (tmp !== undefined) {
-          res += `"${strEscape(key)}":${tmp},`
+          res += `${separator}"${strEscape(key)}":${tmp}`
+          separator = ','
         }
-      }
-      key = keys[i]
-      const tmp = stringifySimple(key, value[key], stack)
-      if (tmp !== undefined) {
-        res += `"${strEscape(key)}":${tmp}`
       }
       res += '}'
       stack.pop()

--- a/test.js
+++ b/test.js
@@ -359,3 +359,21 @@ test('indentation with elements', function (assert) {
   assert.is(actual, expected)
   assert.end()
 })
+
+test('object with undefined values', function (assert) {
+  let obj, expected, actual
+
+  obj = { a: 1, c: undefined, b: 'hello' }
+
+  expected = JSON.stringify(obj)
+  actual = stringify(obj)
+  assert.is(actual, expected)
+
+  obj = { b: 'hello', a: undefined, c: 1 }
+
+  expected = JSON.stringify(obj)
+  actual = stringify(obj)
+  assert.is(actual, expected)
+
+  assert.end()
+})


### PR DESCRIPTION
When the last property (alphabetically) in an object is undefined, a trailing comma is serialised.

safeStableStringify({ a: 1, c: undefined, b: 'hello' })

=>

{"a":1,"b":"hello",}
