### PR TITLE
Support BigInts

### DIFF
--- a/stable.js
+++ b/stable.js
@@ -141,6 +141,8 @@ function stringifyFullFn (key, parent, stack, replacer, indent) {
     case 'number':
       // JSON numbers must be finite. Encode non-finite numbers as null.
       return isFinite(value) ? String(value) : 'null'
+    case 'bigint':
+      return String(value)
     case 'boolean':
       return value === true ? 'true' : 'false'
   }
@@ -223,6 +225,8 @@ function stringifyFullArr (key, value, stack, replacer, indent) {
     case 'number':
       // JSON numbers must be finite. Encode non-finite numbers as null.
       return isFinite(value) ? String(value) : 'null'
+    case 'bigint':
+      return String(value)
     case 'boolean':
       return value === true ? 'true' : 'false'
   }
@@ -312,6 +316,8 @@ function stringifyIndent (key, value, stack, indent) {
     case 'number':
       // JSON numbers must be finite. Encode non-finite numbers as null.
       return isFinite(value) ? String(value) : 'null'
+    case 'bigint':
+      return String(value)
     case 'boolean':
       return value === true ? 'true' : 'false'
   }
@@ -378,6 +384,8 @@ function stringifyReplacerArr (key, value, stack, replacer) {
     case 'number':
       // JSON numbers must be finite. Encode non-finite numbers as null.
       return isFinite(value) ? String(value) : 'null'
+    case 'bigint':
+      return String(value)
     case 'boolean':
       return value === true ? 'true' : 'false'
   }
@@ -444,6 +452,8 @@ function stringifyReplacerFn (key, parent, stack, replacer) {
     case 'number':
       // JSON numbers must be finite. Encode non-finite numbers as null.
       return isFinite(value) ? String(value) : 'null'
+    case 'bigint':
+      return String(value)
     case 'boolean':
       return value === true ? 'true' : 'false'
   }
@@ -516,6 +526,8 @@ function stringifySimple (key, value, stack) {
       // JSON numbers must be finite. Encode non-finite numbers as null.
       // Convert the numbers implicit to a string instead of explicit.
       return isFinite(value) ? String(value) : 'null'
+    case 'bigint':
+      return String(value)
     case 'boolean':
       return value === true ? 'true' : 'false'
   }

--- a/test.js
+++ b/test.js
@@ -206,6 +206,13 @@ test('null property', function (assert) {
   assert.end()
 })
 
+test('bigint property', function (assert) {
+  const obj = { f: 2n ** 64n }
+  const actual = stringify(obj)
+  assert.is(actual, '{"f":18446744073709551616}')
+  assert.end()
+})
+
 test('nested child circular reference in toJSON', function (assert) {
   var circle = { some: 'data' }
   circle.circle = circle


### PR DESCRIPTION
I'm not sure whether this library aims to support big integers, therefore do feel free to close this one if you don't want to support them, as I understand they might be considered as an edge case of some sort.
`JSON.stringify` does not support them as of now, however there is a somewhat related discussion taking place in [proposal-json-parse-with-source](https://github.com/tc39/proposal-json-parse-with-source).
The primary reason for opening the PR was the fact we have to support big ints in our own code, and given the change is relatively small, both in size & the impact on existing functionality, I thought  it might be worth sharing with others.

EDIT:
Seems like I'd need to avoid running that test on Node 8 that does not support BigInts
