### PR TITLE
feature: accept undefined as circularValue option

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,9 @@
+**/*
+!index.d.ts
+!index.js
+!LICENSE
+!package.json
+!esm/*
+!CHANGELOG.md
+!readme.md
+!tsconfig.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.2.0
+
+- Accept `undefined` as `circularValue` option to remove circular values from the serialized output
+
 ## v2.1.0
 
 - Added `maximumBreadth` option to limit stringification at a specific object or array "width" (number of properties / values)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,18 @@
 
 ## v2.2.0
 
-- Accept `undefined` as `circularValue` option to remove circular values from the serialized output
+- Accept `undefined` as `circularValue` option to remove circular properties from the serialized output:
+
+```js
+import { configure } from 'safe-stable-stringify'
+
+const object = { array: [] }
+object.circular = object;
+object.array.push(object)
+
+configure({ circularValue: undefined })(object)
+// '{"array":[null]}'
+```
 
 ## v2.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v2.2.0
 
+- Reduce module size by removing the test and benchmark files from the published package
 - Accept `undefined` as `circularValue` option to remove circular properties from the serialized output:
 
 ```js

--- a/index.js
+++ b/index.js
@@ -121,8 +121,10 @@ function getCircularValueOption (options) {
     var circularValue = options.circularValue
     if (typeof circularValue === 'string') {
       circularValue = `"${circularValue}"`
+    } else if (circularValue === undefined) {
+      return
     } else if (circularValue !== null) {
-      throw new TypeError('The "circularValue" argument must be of type string or the value null')
+      throw new TypeError('The "circularValue" argument must be of type string or the value null or undefined')
     }
   }
   return circularValue === undefined ? '"[Circular]"' : circularValue

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,9 @@ stringify(circular, ['a', 'b'], 2)
 
 * `bigint` {boolean} If `true`, bigint values are converted to a number. Otherwise
   they are ignored. **Default:** `true`.
-* `circularValue` {string|null} Define the value for circular references. **Default:** `[Circular]`.
+* `circularValue` {string|null|undefined} Define the value for circular
+  references. Circular values are not serialized, if set to `undefined`.
+  **Default:** `[Circular]`.
 * `deterministic` {boolean} If `true`, guarantee a deterministic key order
   instead of relying on the insertion order. **Default:** `true`.
 * `maximumBreadth` {number} Maximum number of entries to serialize per object

--- a/readme.md
+++ b/readme.md
@@ -44,9 +44,9 @@ stringify(circular, ['a', 'b'], 2)
 
 * `bigint` {boolean} If `true`, bigint values are converted to a number. Otherwise
   they are ignored. **Default:** `true`.
-* `circularValue` {string|null|undefined} Define the value for circular
-  references. Circular values are not serialized, if set to `undefined`.
-  **Default:** `[Circular]`.
+* `circularValue` {string|null|undefined} Defines the value for circular
+  references. Set to `undefined`, circular properties are not serialized (array
+  entries are replaced with `null`). **Default:** `[Circular]`.
 * `deterministic` {boolean} If `true`, guarantee a deterministic key order
   instead of relying on the insertion order. **Default:** `true`.
 * `maximumBreadth` {number} Maximum number of entries to serialize per object
@@ -93,10 +93,10 @@ console.log(stringified)
 
 ## Differences to JSON.stringify
 
-1. Replace circular structures with the string `[Circular]` (the value may be changed).
-1. Sorted keys instead of using the insertion order (it is possible to deactivate this).
-1. BigInt values are stringified as regular number instead of throwing a TypeError.
-1. Boxed primitives (e.g., `Number(5)`) are not unboxed and are handled as
+1. _Circular values_ are replaced with the string `[Circular]` (the value may be changed).
+1. _Object keys_ are sorted instead of using the insertion order (it is possible to deactivate this).
+1. _BigInt_ values are stringified as regular number instead of throwing a TypeError.
+1. _Boxed primitives_ (e.g., `Number(5)`) are not unboxed and are handled as
    regular object.
 
 Those are the only differences to `JSON.stringify()`. This is a side effect free
@@ -105,8 +105,8 @@ with `JSON.stringify()`.
 
 ## Performance / Benchmarks
 
-Currently this is by far the fastest known stable stringify implementation.
-This is especially important for big objects and TypedArrays.
+Currently this is by far the fastest known stable (deterministic) stringify
+implementation. This is especially important for big objects and TypedArrays.
 
 (Dell Precision 5540, i7-9850H CPU @ 2.60GHz, Node.js 16.11.1)
 

--- a/test.js
+++ b/test.js
@@ -542,7 +542,7 @@ test('no bigint without indentation', function (assert) {
   assert.end()
 })
 
-test('circular value option', function (assert) {
+test('circular value option should allow strings and null', function (assert) {
   let stringifyCircularValue = stringify.configure({ circularValue: 'YEAH!!!' })
 
   const obj = {}
@@ -551,14 +551,31 @@ test('circular value option', function (assert) {
   const expected = '{"circular":"YEAH!!!"}'
   const actual = stringifyCircularValue(obj)
   assert.equal(actual, expected)
-  assert.equal(actual, expected)
   assert.equal(stringify(obj), '{"circular":"[Circular]"}')
-
-  // @ts-expect-error
-  assert.throws(() => stringify.configure({ circularValue: { objects: 'are not allowed' } }), /circularValue/)
 
   stringifyCircularValue = stringify.configure({ circularValue: null })
   assert.equal(stringifyCircularValue(obj), '{"circular":null}')
+
+  assert.end()
+})
+
+test('circular value option should throw for invalid values', function (assert) {
+  // @ts-expect-error
+  assert.throws(() => stringify.configure({ circularValue: { objects: 'are not allowed' } }), /circularValue/)
+
+  assert.end()
+})
+
+test('circular value option set to undefined should skip serialization', function (assert) {
+  const stringifyCircularValue = stringify.configure({ circularValue: undefined })
+
+  const obj = { a: 1 }
+  obj.circular = obj
+  obj.b = [2, obj]
+
+  const expected = '{"a":1,"b":[2,null]}'
+  const actual = stringifyCircularValue(obj)
+  assert.equal(actual, expected)
 
   assert.end()
 })


### PR DESCRIPTION
Added `undefined` to the `circularValue` as accepted value. Use that
to remove circular values from the serialized output.