### PR TITLE
fix: make sure environments without negative lookbehind work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v2.3.1
+
+- Fix `invalid regexp group` error in browsers or environments that do not support the negative lookbehind regular expression assertion.
+
 ## v2.3.0
 
 - Accept the `Error` constructor as `circularValue` option to throw on circular references as the regular JSON.stringify would:

--- a/index.js
+++ b/index.js
@@ -18,9 +18,9 @@ exports.configure = configure
 module.exports = stringify
 
 // eslint-disable-next-line
-const strEscapeSequencesRegExp = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]|[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/
+const strEscapeSequencesRegExp = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]|[\ud800-\udbff](?![\udc00-\udfff])|(?:[^\ud800-\udbff]|^)[\udc00-\udfff]/
 // eslint-disable-next-line
-const strEscapeSequencesReplacer = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]|[\ud800-\udbff](?![\udc00-\udfff])|(?<![\ud800-\udbff])[\udc00-\udfff]/g
+const strEscapeSequencesReplacer = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]|[\ud800-\udbff](?![\udc00-\udfff])|(?:[^\ud800-\udbff]|^)[\udc00-\udfff]/g
 
 // Escaped special characters. Use empty strings to fill up unused entries.
 const meta = [
@@ -40,6 +40,10 @@ const meta = [
 ]
 
 function escapeFn (str) {
+  if (str.length === 2) {
+    const charCode = str.charCodeAt(1)
+    return `${str[0]}\\u${charCode.toString(16)}`
+  }
   const charCode = str.charCodeAt(0)
   return meta.length > charCode
     ? meta[charCode]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "safe-stable-stringify",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Deterministic and safely JSON.stringify to quickly serialize JavaScript objects",
   "exports": {
     "require": "./index.js",


### PR DESCRIPTION
This changes the regular expression that detects characters that
require escaping not to use a negative lookbehind.

Fixes: #26