### PR TITLE
fix: add types for ./esm/wrapper.js

### DIFF
--- a/esm/wrapper.d.ts
+++ b/esm/wrapper.d.ts
@@ -1,0 +1,18 @@
+export function stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
+export function stringify(value: any, replacer?: (number | string)[] | null, space?: string | number): string;
+
+export interface StringifyOptions {
+  bigint?: boolean,
+  circularValue?: string | null | TypeErrorConstructor | ErrorConstructor,
+  deterministic?: boolean,
+  maximumBreadth?: number,
+  maximumDepth?: number,
+}
+
+export namespace stringify {
+  export function configure(options: StringifyOptions): typeof stringify;
+}
+
+export function configure(options: StringifyOptions): typeof stringify;
+
+export default stringify;


### PR DESCRIPTION
Fixes: #32 

I simply copy-pasted the same `types.d.ts` file to the folder `./esm` and renamed it to `wrapper.d.ts`.

I want to note that there is another solution: improving the `exports` condition of `package.json` such that TypeScript looks at `index.d.ts` when resolving types for `./esm/wrapper.js`:

```jsonc
"exports": {
  "require": "./index.js",
  "import": {
    "types": "./index.d.ts",
    "default": "./esm/wrapper.js"
  }
}
```

I decided to solve it adding `wrapper.d.ts` because this "types exports condition" seems to be supported only since TS 4.7 ([devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing)).