### PR TITLE
fix(types): support typescript ESM resolution

### DIFF
--- a/esm/wrapper.d.ts
+++ b/esm/wrapper.d.ts
@@ -1,1 +1,4 @@
-export * from '../index.d'
+import { stringify } from '../index.js';
+
+export * from '../index.js';
+export default stringify;


### PR DESCRIPTION
Hi, thanks for the awesome library!

I noticed when I upgraded to 2.4.1 that I started getting TS compiler errors (when using `module: "nodenext"` and `moduleResolution: "nodenext"`), which should be fixed by the changes below. In particular, there are two changes:

1. `export * from` doesn't re-export the default export, so I had to add that explicitly.
2. Under `moduleResoultion: 'nodenext'`, `'../index.d'` is not an allowed path name, as TS requires the full extension be included in this mode; without it, you get a "cannot find module" error. Meanwhile, using `../index.d.ts` as the path doesn't work either; TS says: "An import path cannot end with a '.d.ts' extension. Consider importing '../index.js' instead."