### PR TITLE
Allow passing a comparator function to the `deterministic` option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ export function stringify(value: unknown, replacer?: ((key: string, value: unkno
 export interface StringifyOptions {
   bigint?: boolean,
   circularValue?: string | null | TypeErrorConstructor | ErrorConstructor,
-  deterministic?: boolean,
+  deterministic?: boolean | ((a: string, b: string) => number),
   maximumBreadth?: number,
   maximumDepth?: number,
   strict?: boolean,

--- a/index.js
+++ b/index.js
@@ -188,8 +188,8 @@ function configure (options) {
   }
   const circularValue = getCircularValueOption(options)
   const bigint = getBooleanOption(options, 'bigint')
-  const deterministicOption = getDeterministicOption(options, 'deterministic')
-  const deterministic = typeof deterministicOption === "function" ? true : deterministicOption
+  const deterministic = getDeterministicOption(options, 'deterministic')
+  const comparator = typeof deterministic === "function" ? deterministic : undefined
   const maximumDepth = getPositiveIntegerOption(options, 'maximumDepth')
   const maximumBreadth = getPositiveIntegerOption(options, 'maximumBreadth')
   const comparator = typeof deterministicOption === "function" 

--- a/index.js
+++ b/index.js
@@ -189,7 +189,7 @@ function configure (options) {
   const circularValue = getCircularValueOption(options)
   const bigint = getBooleanOption(options, 'bigint')
   const deterministic = getDeterministicOption(options, 'deterministic')
-  const comparator = typeof deterministic === "function" ? deterministic : undefined
+  const comparator = typeof deterministic === 'function' ? deterministic : undefined
   const maximumDepth = getPositiveIntegerOption(options, 'maximumDepth')
   const maximumBreadth = getPositiveIntegerOption(options, 'maximumBreadth')
 

--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function getDeterministicOption (options, key) {
     if (typeof value === 'boolean') {
       return value
     }
-    if (typeof value === 'function' && value.length === 2) {
+    if (typeof value === 'function') {
       return value
     }
   }

--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ function insertSort (array, comparator) {
   for (let i = 1; i < array.length; i++) {
     const currentValue = array[i]
     let position = i
-    while (position !== 0 && comparator(array[position - 1], currentValue) > 0) {
+    while (position !== 0 && array[position - 1] > currentValue) {
       array[position] = array[position - 1]
       position--
     }

--- a/index.js
+++ b/index.js
@@ -192,18 +192,6 @@ function configure (options) {
   const comparator = typeof deterministic === "function" ? deterministic : undefined
   const maximumDepth = getPositiveIntegerOption(options, 'maximumDepth')
   const maximumBreadth = getPositiveIntegerOption(options, 'maximumBreadth')
-  const comparator = typeof deterministicOption === "function" 
-      ? deterministicOption 
-      : (a, b) => {
-        // We can safely assume that the input values are always strings in this case
-        if (a < b) {
-          return -1;
-        }
-        if (a > b) {
-          return 1;
-        }
-        return 0;
-      }
 
   function stringifyFnReplacer (key, parent, stack, replacer, spacer, indentation) {
     let value = parent[key]

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function strEscape (str) {
 function insertSort (array, comparator) {
   // Insertion sort is very efficient for small input sizes, but it has a bad
   // worst case complexity. Thus, use native array sort for bigger values.
-  if (array.length > 2e2) {
+  if (array.length > 2e2 || comparator) {
     return array.sort(comparator)
   }
   for (let i = 1; i < array.length; i++) {

--- a/test.js
+++ b/test.js
@@ -1303,3 +1303,44 @@ test('strict option replacer array', (assert) => {
 
   assert.end()
 })
+
+test('deterministic option possibilities', (assert) => {
+  assert.throws(() => {
+    // @ts-expect-error
+    stringify.configure({ deterministic: 1 })
+  }, {
+    message: 'The "deterministic" argument must be of type boolean or comparator function',
+    name: 'TypeError'
+  })
+
+  const serializer1 = stringify.configure({ deterministic: false })
+  serializer1(NaN)
+  
+  const serializer2 = stringify.configure({ deterministic: (a, b) => a.localeCompare(b) })
+  serializer2(NaN)
+
+  assert.end()
+})
+
+test('deterministic default sorting', function (assert) {
+  const serializer = stringify.configure({ deterministic: true })
+  
+  const obj = { b: 2, c: 3, a: 1 }
+  const expected = '{\n "a": 1,\n "b": 2,\n "c": 3\n}'
+  const actual = serializer(obj, null, 1)
+  assert.equal(actual, expected)
+  
+  assert.end()
+})
+
+test('deterministic custom sorting', function (assert) {
+  // Descending
+  const serializer = stringify.configure({ deterministic: (a, b) => b.localeCompare(a) })
+
+  const obj = { b: 2, c: 3, a: 1 }
+  const expected = '{\n "c": 3,\n "b": 2,\n "a": 1\n}'
+  const actual = serializer(obj, null, 1)
+  assert.equal(actual, expected)
+
+  assert.end()
+})

--- a/test.js
+++ b/test.js
@@ -1315,7 +1315,7 @@ test('deterministic option possibilities', (assert) => {
 
   const serializer1 = stringify.configure({ deterministic: false })
   serializer1(NaN)
-  
+
   const serializer2 = stringify.configure({ deterministic: (a, b) => a.localeCompare(b) })
   serializer2(NaN)
 
@@ -1324,12 +1324,12 @@ test('deterministic option possibilities', (assert) => {
 
 test('deterministic default sorting', function (assert) {
   const serializer = stringify.configure({ deterministic: true })
-  
+
   const obj = { b: 2, c: 3, a: 1 }
   const expected = '{\n "a": 1,\n "b": 2,\n "c": 3\n}'
   const actual = serializer(obj, null, 1)
   assert.equal(actual, expected)
-  
+
   assert.end()
 })
 


### PR DESCRIPTION
This allows to use a custom comparator function for the deterministic sorting of object keys.

Closes #48

@BridgeAR I'm not very familiar with JS, so please feel free to suggest improvements 🙂 