### PR TITLE
Adds `object-identity` as known alternative

### DIFF
--- a/compare.js
+++ b/compare.js
@@ -13,29 +13,23 @@ const stringifyPackages = {
   'faster-stable-stringify': true,
   'json-stringify-deterministic': true,
   'fast-safe-stringify': 'stable',
-  'object-identity': import('object-identity').then(m => m.identify),
+  'object-identity': 'identify',
   'safe-stable-stringify': require('.')
 }
 
-async function main () {
-  for (const name in stringifyPackages) {
-    let fn
-    if (typeof stringifyPackages[name] === 'function') {
-      fn = stringifyPackages[name]
-    } else if (typeof stringifyPackages[name] === 'string') {
-      fn = require(name)[stringifyPackages[name]]
-    } else if (typeof stringifyPackages[name].then === 'function') {
-      fn = await stringifyPackages[name]
-    } else {
-      fn = require(name)
-    }
-
-    suite.add(name, function () {
-      fn(testData)
-    })
+for (const name in stringifyPackages) {
+  let fn
+  if (typeof stringifyPackages[name] === 'function') {
+    fn = stringifyPackages[name]
+  } else if (typeof stringifyPackages[name] === 'string') {
+    fn = require(name)[stringifyPackages[name]]
+  } else {
+    fn = require(name)
   }
+
+  suite.add(name, function () {
+    fn(testData)
+  })
 }
 
-main().then(function () {
-	suite.run()
-})
+suite.run()

--- a/compare.js
+++ b/compare.js
@@ -13,22 +13,29 @@ const stringifyPackages = {
   'faster-stable-stringify': true,
   'json-stringify-deterministic': true,
   'fast-safe-stringify': 'stable',
+  'object-identity': import('object-identity').then(m => m.identify),
   'safe-stable-stringify': require('.')
 }
 
-for (const name in stringifyPackages) {
-  let fn
-  if (typeof stringifyPackages[name] === 'function') {
-    fn = stringifyPackages[name]
-  } else if (typeof stringifyPackages[name] === 'string') {
-    fn = require(name)[stringifyPackages[name]]
-  } else {
-    fn = require(name)
-  }
+async function main () {
+  for (const name in stringifyPackages) {
+    let fn
+    if (typeof stringifyPackages[name] === 'function') {
+      fn = stringifyPackages[name]
+    } else if (typeof stringifyPackages[name] === 'string') {
+      fn = require(name)[stringifyPackages[name]]
+    } else if (typeof stringifyPackages[name].then === 'function') {
+      fn = await stringifyPackages[name]
+    } else {
+      fn = require(name)
+    }
 
-  suite.add(name, function () {
-    fn(testData)
-  })
+    suite.add(name, function () {
+      fn(testData)
+    })
+  }
 }
 
-suite.run()
+main().then(function () {
+	suite.run()
+})

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "json-stable-stringify": "^1.3.0",
     "json-stringify-deterministic": "^1.0.12",
     "json-stringify-safe": "^5.0.1",
+    "object-identity": "^0.2.1",
     "bench-node": "^0.14.0",
     "standard": "^17.1.2",
     "tap": "^16.3.10",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "json-stable-stringify": "^1.3.0",
     "json-stringify-deterministic": "^1.0.12",
     "json-stringify-safe": "^5.0.1",
-    "object-identity": "^0.2.1",
+    "object-identity": "^0.2.2",
     "bench-node": "^0.14.0",
     "standard": "^17.1.2",
     "tap": "^16.3.10",

--- a/readme.md
+++ b/readme.md
@@ -162,13 +162,15 @@ indentation:   deep circular x 16,443 ops/sec ±0.40% (97 runs sampled)
 Comparing `safe-stable-stringify` with known alternatives:
 
 ```md
-fast-json-stable-stringify x 18,765 ops/sec ±0.71% (94 runs sampled)
-json-stable-stringify x 13,870 ops/sec ±0.72% (94 runs sampled)
-fast-stable-stringify x 21,343 ops/sec ±0.33% (95 runs sampled)
-faster-stable-stringify x 17,707 ops/sec ±0.44% (97 runs sampled)
-json-stringify-deterministic x 11,208 ops/sec ±0.57% (98 runs sampled)
-fast-safe-stringify x 21,460 ops/sec ±0.75% (99 runs sampled)
-this x 30,367 ops/sec ±0.39% (96 runs sampled)
+fastest-stable-stringify x 53,720 ops/sec (11 runs sampled)
+fast-json-stable-stringify x 48,530 ops/sec (11 runs sampled)
+json-stable-stringify x 38,123 ops/sec (11 runs sampled)
+fast-stable-stringify x 54,064 ops/sec (12 runs sampled)
+faster-stable-stringify x 47,958 ops/sec (10 runs sampled)
+json-stringify-deterministic x 35,306 ops/sec (10 runs sampled)
+fast-safe-stringify x 44,133 ops/sec (10 runs sampled)
+object-identity x 103,553 ops/sec (13 runs sampled)
+this x 48,175 ops/sec (11 runs sampled)
 
 The fastest is this
 ```


### PR DESCRIPTION
Hey, thanks for building and maintaining `safe-stable-stringify`. 🎉 

I have been doing some comparison work against other stable stringify/canonicalization  libraries when building [`object-identity`](https://github.com/maraisr/object-identity) after I saw some big perf wins. I think there is useful overlap in this space, and hopefully improvements here help both projects rise with the tide.

This PR updates the compare script so it can handle ESM-only alternatives, and added `object-identity` there.

I also ran `npm run compare` to re-generate the readme doc, but can see you run that again on your stable machine.